### PR TITLE
Fix test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,22 +2,25 @@ name: "build-test"
 on: # rebuild any PRs and main branch changes
   pull_request:
   push:
-    branches:
-      - master
-      - 'releases/*'
 
 jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+          node-version: '16'
     - run: |
         npm install
         npm run all
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+          node-version: '16'
     - uses: ./
       with: 
         milliseconds: 1000


### PR DESCRIPTION
Need to use setup-node to use Node 16. Otherwise, the Ubuntu-latest will use the [built-in Node 18](https://github.com/actions/runner-images/blob/ubuntu22/20230821.1/images/linux/Ubuntu2204-Readme.md#language-and-runtime).